### PR TITLE
FIX : Replace main a fake store api url w/ its herokuapp url

### DIFF
--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { ShoppingWheelComponent } from './shopping-wheel/shopping-wheel.componen
 import { CartState } from './store/states/cart.state';
 import { FakeStoreState } from './store/states/fake-store.state';
 import { SalesDetailState } from './store/states/sales-detail.state';
+import { ReplaceAFakeStoreApiUrlPipe } from './pipes/replace-afake-store-api-url.pipe';
 
 @NgModule({
     declarations: [
@@ -30,6 +31,7 @@ import { SalesDetailState } from './store/states/sales-detail.state';
         CheckoutComponent,
         ShoppingWheelComponent,
         ProductCardComponent,
+        ReplaceAFakeStoreApiUrlPipe,
     ],
     imports: [
         BrowserModule,

--- a/client/src/app/pipes/replace-afake-store-api-url.pipe.spec.ts
+++ b/client/src/app/pipes/replace-afake-store-api-url.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { ReplaceAFakeStoreApiUrlPipe } from './replace-afake-store-api-url.pipe';
+
+describe('ReplaceAFakeStoreApiUrlPipe', () => {
+  it('create an instance', () => {
+    const pipe = new ReplaceAFakeStoreApiUrlPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/client/src/app/pipes/replace-afake-store-api-url.pipe.ts
+++ b/client/src/app/pipes/replace-afake-store-api-url.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'replaceAFakeStoreApiUrl',
+})
+export class ReplaceAFakeStoreApiUrlPipe implements PipeTransform {
+    mainUrl: string = 'https://fakestoreapi.com';
+    alternateUrl: string = 'https://fakestoreapi.herokuapp.com';
+
+    transform(url: string): string {
+        if (!url.includes(this.mainUrl)) {
+            return url;
+        }
+        return url.replace(`${this.mainUrl}/`, `${this.alternateUrl}/`);
+    }
+}

--- a/client/src/app/product-card/product-card.component.html
+++ b/client/src/app/product-card/product-card.component.html
@@ -1,6 +1,6 @@
 <div class="d-block mx-auto py-3" style="max-width: 17rem">
     <img
-        [src]="product.image"
+        [src]="product.image | replaceAFakeStoreApiUrl"
         class="mx-auto d-block"
         style="height: 15rem; object-fit: contain; max-width: 17rem"
     />

--- a/client/src/app/services/fake-store-api.service.ts
+++ b/client/src/app/services/fake-store-api.service.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@angular/core';
     providedIn: 'root',
 })
 export class FakeStoreApiService {
-    private fakeStoreApiUrl: string = 'https://fakestoreapi.com';
+    private fakeStoreApiUrl: string = 'https://fakestoreapi.herokuapp.com';
 
     constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
When a fake store api is shutdown, temporarily using alternate url